### PR TITLE
Update to work with 32 bit Pi

### DIFF
--- a/server/commandCenter.go
+++ b/server/commandCenter.go
@@ -93,7 +93,7 @@ func (c *CommandCenter) ProcessCommand(data []byte) {
 		c.respondToSuspend(false)
 		return
 	case OPCODE_BASAL__SET_TEMPORARY_BASAL:
-		c.respondToTempBasal(OPCODE_BASAL__SET_TEMPORARY_BASAL, int(data[2]), time.Duration(int(data[3])*int(time.Hour)))
+		c.respondToTempBasal(OPCODE_BASAL__SET_TEMPORARY_BASAL, int(data[2]), time.Duration(data[3])*time.Hour)
 		return
 	case OPCODE_BASAL__APS_SET_TEMPORARY_BASAL:
 		var percentage = int(data[2]) + (int(data[3]) << 8)


### PR DESCRIPTION
When trying to execute `go run .` on a Pi 3 B+ running in 32-bit, I kept getting this error:

```
# dana/simulator/server
server/commandCenter.go:96:104: cosntant 3600000000000 overflows int
```

After applying this commit, it executed fine and connected to my iPhone.